### PR TITLE
Send ExpressionEngine no_results if there are no results.

### DIFF
--- a/pi.rest.php
+++ b/pi.rest.php
@@ -123,6 +123,12 @@ class Rest
 		}
 
 		// -------------------------------------------
+		
+		// If no results, return EE no results
+		if ( $response == new stdClass() )
+		{
+			return $this->return_data = $this->EE->TMPL->no_results();
+		}
 
 		// Only return if there is something worth returning
 		if ( ! empty($return))


### PR DESCRIPTION
Uses the ExpressionEngine Template class' no_results() function to indicate that there were no results returned and allow the use of EE's built in {if no_results} conditional in templates using Rest.
